### PR TITLE
re-added compatibility for taking in shaders as a string

### DIFF
--- a/simple-shader.js
+++ b/simple-shader.js
@@ -1,5 +1,5 @@
 /*
-  simple-shader.js v0.3.3
+  simple-shader.js v0.3.4
   written by Sudospective
   special thanks to Spax for debugging and feature requests
   
@@ -159,8 +159,8 @@ export class SimpleShader {
       //console.log(text);
       return text;
     }
-    const vertProm = /\s|\n/.test(data.vert) ? data.vert : fetchVert(data.vert);
-    const fragProm = /\s|\n/.test(data.frag) ? data.frag : fetchFrag(data.frag);
+    const vertProm = /\n/.test(data.vert) ? data.vert : fetchVert(data.vert);
+    const fragProm = /\n/.test(data.frag) ? data.frag : fetchFrag(data.frag);
     let vertSrc = "";
     let fragSrc = "";
     Promise.all([vertProm, fragProm])

--- a/simple-shader.js
+++ b/simple-shader.js
@@ -1,5 +1,5 @@
 /*
-  simple-shader.js v0.3.2
+  simple-shader.js v0.3.3
   written by Sudospective
   special thanks to Spax for debugging and feature requests
   
@@ -159,10 +159,8 @@ export class SimpleShader {
       //console.log(text);
       return text;
     }
-    //const vertProm = (data.vert.substring(0,1)==="#") ? data.vert : fetchVert(data.vert);
-    //const fragProm = (data.frag.substring(0,1)==="#") ? data.frag : fetchFrag(data.frag);
-    const vertProm = fetchVert(data.vert);
-    const fragProm = fetchFrag(data.frag);
+    const vertProm = /\s|\n/.test(data.vert) ? data.vert : fetchVert(data.vert);
+    const fragProm = /\s|\n/.test(data.frag) ? data.frag : fetchFrag(data.frag);
     let vertSrc = "";
     let fragSrc = "";
     Promise.all([vertProm, fragProm])


### PR DESCRIPTION
it's a dumb check, just looks for newlines. this *does* mean that minified shaders as a string will technically not work, but you have to put a `#version 300 es` on the first line by itself so minified code *will* have to have at least one newline still (probably).